### PR TITLE
Add Cython file needed to build to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include src/adeft/nlp/stopwords.json
 graft src/adeft/gui/ground/static
 graft src/adeft/gui/ground/templates
+include src/adeft/score/_score.pyx


### PR DESCRIPTION
This PR adds `_score.pyx` to MANIFEST.in. In #77, `_score.pyx` was made a required file for building adeft, and creating an sdist will not work if this file is not included in the built package.