### PR TITLE
Constrain scikit-learn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 requires-python = ">=3.7"
 dependencies = [
              "nltk",
-             "scikit-learn>=1.0",
+             "scikit-learn>=1.0,<1.5",
              "boto3",
              "flask",
              "appdirs"


### PR DESCRIPTION
Based on #80 this PR adds a version constraint for `scikit-learn` which has just released version 1.5 and this new version causes issues.